### PR TITLE
3: make arguments extendable

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -12,7 +12,7 @@ describe("declare component", () => {
     const Component = declareComponent<{ x: number }>(({ x }) => {
       const y = atom((ctx) => ctx.spy(x) + 1);
 
-      return (ctx) => {
+      return ({ ctx }) => {
         return <div>{ctx.spy(y)}</div>;
       };
     });
@@ -34,7 +34,7 @@ describe("declare component", () => {
     const Component = declareComponent<{ x?: number }>(({ x }) => {
       const y = atom((ctx) => (ctx.spy(x) ?? 0) + 1);
 
-      return (ctx) => {
+      return ({ ctx }) => {
         return <div>{ctx.spy(y)}</div>;
       };
     });
@@ -120,7 +120,7 @@ describe("declare component", () => {
         const initChild = vi.fn();
         const Child = declareComponent<{ x: number }>(({ x }) => {
           initChild();
-          return (ctx) => {
+          return ({ ctx }) => {
             return <div>{ctx.spy(x)}</div>;
           };
         });
@@ -129,7 +129,7 @@ describe("declare component", () => {
         const renderParent = vi.fn();
         const Parent = declareComponent<{ x: number }>(({ x }) => {
           initParent();
-          return (ctx) => {
+          return () => {
             renderParent();
             return <Child x={x} />;
           };
@@ -152,7 +152,7 @@ describe("declare component", () => {
         const count = vi.fn();
         const Component = declareComponent<{ x: number }>(({ x }) => {
           count();
-          return (ctx) => {
+          return ({ ctx }) => {
             return <div>{ctx.spy(x)}</div>;
           };
         });
@@ -170,7 +170,7 @@ describe("declare component", () => {
       test("primitive => primitive", () => {
         const count = vi.fn();
         const Component = declareComponent<{ x: number }>(({ x }) => {
-          return (ctx) => {
+          return ({ ctx }) => {
             count();
             return <div>{ctx.spy(x)}</div>;
           };
@@ -185,7 +185,7 @@ describe("declare component", () => {
       test("primitive => atom", () => {
         const count = vi.fn();
         const Component = declareComponent<{ x: number }>(({ x }) => {
-          return (ctx) => {
+          return ({ ctx }) => {
             count();
             return <div>{ctx.spy(x)}</div>;
           };
@@ -200,7 +200,7 @@ describe("declare component", () => {
       test("atom => atom", () => {
         const count = vi.fn();
         const Component = declareComponent<{ x: number }>(({ x }) => {
-          return (ctx) => {
+          return ({ ctx }) => {
             count();
             return <div>{ctx.spy(x)}</div>;
           };
@@ -215,7 +215,7 @@ describe("declare component", () => {
       test("atom => primitive", () => {
         const count = vi.fn();
         const Component = declareComponent<{ x: number }>(({ x }) => {
-          return (ctx) => {
+          return ({ ctx }) => {
             count();
             return <div>{ctx.spy(x)}</div>;
           };
@@ -235,7 +235,7 @@ describe("declare component", () => {
         ctx.spy(x) !== undefined ? "defined1" : "undefined2",
       );
 
-      return (ctx) => {
+      return ({ ctx }) => {
         return <div>{ctx.spy(y)}</div>;
       };
     });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,9 +22,15 @@ type OutsideProps<Props> = {
 };
 type ReturnComponent<Props> = React.FC<OutsideProps<Props>>;
 
-type RenderF = (ctx: CtxSpy) => React.ReactElement;
-
-type Component<Props> = (props: InsideProps<Props>) => RenderF;
+type RenderArg = {
+  ctx: CtxSpy;
+};
+type RenderF = (arg: RenderArg) => React.ReactElement;
+type ComponentArg<Props> = {};
+type Component<Props> = (
+  props: InsideProps<Props>,
+  arg: ComponentArg<Props>,
+) => RenderF;
 
 type UnsubscribeFn = () => void;
 const emptyUnsubscribe: UnsubscribeFn = () => {};
@@ -94,11 +100,11 @@ export function declareComponent<Props>(
     setProps(props);
 
     const wrapped = React.useMemo(() => {
-      return component(insideProps);
+      return component(insideProps, {});
     }, []);
 
     const Component = React.useMemo(() => {
-      return React.memo(reatomComponent(({ ctx }) => wrapped(ctx)));
+      return React.memo(reatomComponent(({ ctx }) => wrapped({ ctx })));
     }, []);
 
     return <Component />;


### PR DESCRIPTION
I decided to wrap the ctx only because destructuring is an often-used case. 